### PR TITLE
Fix excessive use of RAM

### DIFF
--- a/prefq/examples/imitation_preference_comparisons.py
+++ b/prefq/examples/imitation_preference_comparisons.py
@@ -171,7 +171,7 @@ video_dir = tempfile.mkdtemp(prefix="videos_")
 
 venv = make_vec_env(env_name = "Pendulum-v1", 
                     rng=rng,
-                    post_wrappers=[lambda env, env_id: RenderImageInfoWrapper(env)],
+                    post_wrappers=[lambda env, env_id: RenderImageInfoWrapper(env, use_file_cache=True)],
 )
 
 reward_net = BasicRewardNet(


### PR DESCRIPTION
- By simply adding setting the according Flag to true, the RenderImageInfoWrapper is capable of storing data in cache memory, avoiding overloaded RAM.