### PR TITLE
Communicate file extension to Server

### DIFF
--- a/prefq/query_client.py
+++ b/prefq/query_client.py
@@ -16,6 +16,7 @@ class QueryClient:
     def send_video_pair(self, query_id, left_filename, right_filename, video_dir):
         """POST-Request: Send videos to Query Server"""
 
+        file_extension = left_filename.split(".")[1]
         left_video_file_path = os.path.join(video_dir, left_filename)
         right_video_file_path = os.path.join(video_dir, right_filename)
 
@@ -39,6 +40,10 @@ class QueryClient:
             ),
             "query_id": (
                 json.dumps(query_id),
+                "application/json",
+            ),
+            "file_extension": (
+                json.dumps(file_extension),
                 "application/json",
             ),
         }

--- a/prefq/server.py
+++ b/prefq/server.py
@@ -125,9 +125,10 @@ def receive_videos():
     print("\n\nServer: Starting receive_videos() [...]")
 
     print("Server: Receiving videos...")
+    file_extension = unquote(request.files.get("file_extension").filename).strip('"')
     query_id = unquote(request.files.get("query_id").filename).strip('"')
-    left_filename = query_id + "-left.webm"
-    right_filename = query_id + "-right.webm"
+    left_filename = query_id + "-left." + file_extension
+    right_filename = query_id + "-right." + file_extension
     left_video = request.files.get("left_video")
     right_video = request.files.get("right_video")
     query_pair = (left_filename, right_filename)


### PR DESCRIPTION
As described in #24 the file extension had no impact on the behavior. Even without specifying it, the rendered videos inside the feedback client window appeared to work just as expected, however, in order to make the project bulletproof for the future it is better to extract the file encoding and communicate it correctly.