### PR TITLE
Support Multi User Feedback

### DIFF
--- a/prefq/server.py
+++ b/prefq/server.py
@@ -108,6 +108,10 @@ def load_web_interface():
             # Get query from list
             query = queries_pending_response[0]
 
+            # Put query at last position in list
+            queries_pending_response.pop(0)
+            queries_pending_response.append(query)
+
         video_filename_left, video_filename_right = query
 
         return flask.render_template(


### PR DESCRIPTION
By maintaining a second level datastructure (implemented as a list), for sent, yet unevaluated queries we can now support multiple labelers.

Non-responded queries are simply be taken out of the list, whenever no queries remain in the queue. To do so, we simply select the oldest unevaluated query `query_list[0]`, remove it from the first position and put it to the last position of the list. This procedure ensures, that we always re-send the oldest unevaluated query.

Closes #40